### PR TITLE
Added `EVENT_REGISTER_CP_URL_RULES` event so beam can be used in CP

### DIFF
--- a/src/Beam.php
+++ b/src/Beam.php
@@ -62,6 +62,14 @@ class Beam extends Plugin
         );
 
         Event::on(
+            UrlManager::class,
+            UrlManager::EVENT_REGISTER_CP_URL_RULES,
+            function (RegisterUrlRulesEvent $event) {
+                $event->rules['beam/download'] = 'beam/default';
+            }
+        );
+
+        Event::on(
             CraftVariable::class,
             CraftVariable::EVENT_INIT,
             function (Event $event) {


### PR DESCRIPTION
Hey @sjelfull I have a module that I use to export client data using Beam and the latest update doesn't work with it because the `beam/download` action is a front-end URL. This just adds the CP URL rule and it works in the CP, now.