### PR TITLE
Set output BOM for Microsoft Excel

### DIFF
--- a/src/services/BeamService.php
+++ b/src/services/BeamService.php
@@ -57,6 +57,7 @@ class BeamService extends Component
         }
 
         $csv = Writer::createFromString('');
+        $csv->setOutputBOM(Writer::BOM_UTF8);
 
         if (!empty($header)) {
             $csv->insertOne($header);


### PR DESCRIPTION
In Microsoft Excel there are issues with the encoding, because Microsoft is expecting a BOM character: https://csv.thephpleague.com/7.0/bom/